### PR TITLE
add default param names to  `SCFNotificationCallback`

### DIFF
--- a/Sources/SCFNotification/SCFNotificationCenter.swift
+++ b/Sources/SCFNotification/SCFNotificationCenter.swift
@@ -1,6 +1,10 @@
 import Foundation
 
-public typealias SCFNotificationCallback<Observer: AnyObject, Object: AnyObject> = (CFNotificationCenter?, Observer?, CFNotificationName?, Object?, CFDictionary?) -> Void
+public typealias SCFNotificationCallback<Observer: AnyObject, Object: AnyObject> = (_ center: CFNotificationCenter?,
+                                                                                    _ observer: Observer?,
+                                                                                    _ name: CFNotificationName?,
+                                                                                    _ object: Object?,
+                                                                                    _ userInfo: CFDictionary?) -> Void
 
 
 public class SCFNotificationCenter {


### PR DESCRIPTION
Xcode will automatically fill in the names of closure parameters.

```swift
SCFNotificationCenter.local
            .addObserver(observer: self, name: nil, suspensionBehavior: .deliverImmediately) { center, observer, name, object, userInfo in
                <#code#>
            }
```