### PR TITLE
Support Privacy Manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,9 @@ let package = Package(
     targets: [
         .target(
             name: "SCFNotification",
-            dependencies: []
+            dependencies: [],
+            path: "Sources",
+            resources: [.copy("Resources/PrivacyInfo.xcprivacy")]
         ),
         .testTarget(
             name: "SCFNotificationTests",

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 5.9
 
 import PackageDescription
 
@@ -22,6 +22,5 @@ let package = Package(
             name: "SCFNotificationTests",
             dependencies: ["SCFNotification"]
         ),
-    ],
-    swiftLanguageModes: [.v6]
+    ]
 )

--- a/Sources/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/Sources/SCFNotification/Extension/Array+.swift
+++ b/Sources/SCFNotification/Extension/Array+.swift
@@ -1,18 +1,19 @@
 //
 //  Array+.swift
-//  
+//
 //
 //  Created by p-x9 on 2023/01/21.
-//  
+//
 //
 
 import Foundation
 
 extension Array where Element == Observation {
-    func remove(observer: UnsafeMutableRawPointer?, name: CFNotificationName?, object: UnsafeRawPointer?) -> Array<Element> {
+    func remove(observer: UnsafeMutableRawPointer?, name: CFNotificationName?, object: UnsafeRawPointer?) -> [Element] {
         filter {
             guard $0.observerPtr == observer,
-                  $0.objectPtr == object else {
+                  $0.objectPtr == object
+            else {
                 return true
             }
 
@@ -24,7 +25,7 @@ extension Array where Element == Observation {
         }
     }
 
-    func removeEvery(observer: UnsafeMutableRawPointer?) -> Array<Element> {
+    func removeEvery(observer: UnsafeMutableRawPointer?) -> [Element] {
         filter {
             guard $0.observerPtr == observer else {
                 return true
@@ -33,13 +34,13 @@ extension Array where Element == Observation {
         }
     }
 
-    func cleanUpped() -> Array<Element> {
+    func cleanUpped() -> [Element] {
         filter {
             $0.observer != nil
         }
     }
 
-    func notifyNeededOnly(observer: UnsafeMutableRawPointer?, name: CFNotificationName?, object: UnsafeRawPointer?) -> Array<Element> {
+    func notifyNeededOnly(observer: UnsafeMutableRawPointer?, name: CFNotificationName?, object: UnsafeRawPointer?) -> [Element] {
         filter {
             var isFiltered = true
 

--- a/Sources/SCFNotification/Extension/CFDictionary+.swift
+++ b/Sources/SCFNotification/Extension/CFDictionary+.swift
@@ -1,0 +1,33 @@
+//
+//  CFDictionary+.swift
+//  SCFNotification
+//
+//  Created by CodingIran on 2025/5/8.
+//
+
+import Foundation
+
+public extension CFDictionary {
+    static func from(_ dict: SCFNotificationUserInfo) -> CFDictionary {
+        dict as CFDictionary
+    }
+
+    var scfNotificationUserInfo: SCFNotificationUserInfo {
+        let nsDict = unsafeBitCast(self, to: NSDictionary.self)
+        var result = SCFNotificationUserInfo()
+
+        for (key, value) in nsDict {
+            if let keyStr = key as? String {
+                result[keyStr] = value
+            }
+        }
+
+        return result
+    }
+}
+
+public extension SCFNotificationUserInfo {
+    var cfDictionary: CFDictionary {
+        CFDictionary.from(self)
+    }
+}

--- a/Sources/SCFNotification/Extension/CFNotificationCenter+.swift
+++ b/Sources/SCFNotification/Extension/CFNotificationCenter+.swift
@@ -1,24 +1,24 @@
 //
 //  CFNotificationCenter+.swift
-//  
+//
 //
 //  Created by p-x9 on 2023/01/21.
-//  
+//
 //
 
 import Foundation
 
-extension CFNotificationCenter {
-    public static var local: CFNotificationCenter {
+public extension CFNotificationCenter {
+    static var local: CFNotificationCenter {
         CFNotificationCenterGetLocalCenter()
     }
 
-    public static var darwinNotify: CFNotificationCenter {
+    static var darwinNotify: CFNotificationCenter {
         CFNotificationCenterGetDarwinNotifyCenter()
     }
 
 #if os(macOS)
-    public static var distributed: CFNotificationCenter {
+    static var distributed: CFNotificationCenter {
         CFNotificationCenterGetDistributedCenter()
     }
 #endif

--- a/Sources/SCFNotification/Extension/CFNotificationName+.swift
+++ b/Sources/SCFNotification/Extension/CFNotificationName+.swift
@@ -1,0 +1,24 @@
+//
+//  CFNotificationName+.swift
+//  SCFNotification
+//
+//  Created by CodingIran on 2025/5/8.
+//
+
+import Foundation
+
+public extension CFNotificationName {
+    init(name: SCFNotificationName) {
+        self = CFNotificationName(rawValue: name as CFString)
+    }
+
+    var scfNotificationName: SCFNotificationName {
+        rawValue as SCFNotificationName
+    }
+}
+
+public extension SCFNotificationName {
+    var cfNotificationName: CFNotificationName {
+        .init(name: self)
+    }
+}

--- a/Sources/SCFNotification/Observation.swift
+++ b/Sources/SCFNotification/Observation.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 
-struct Observation {
-    typealias SCFNotificationCallbackObjC = (CFNotificationCenter?, UnsafeMutableRawPointer?, CFNotificationName?, UnsafeRawPointer?, CFDictionary?) -> Void
+struct Observation: @unchecked Sendable {
+    typealias SCFNotificationCallbackObjC = @Sendable (CFNotificationCenter?, UnsafeMutableRawPointer?, CFNotificationName?, UnsafeRawPointer?, CFDictionary?) -> Void
 
     let name: CFString?
     var notificationName: CFNotificationName? {
@@ -19,8 +19,8 @@ struct Observation {
         return .init(name)
     }
 
-    weak var observer: AnyObject?
-    weak var object: AnyObject?
+    weak var observer: AnySendableObject?
+    weak var object: AnySendableObject?
 
     var observerPtr: UnsafeMutableRawPointer? {
         guard let observer = observer else {
@@ -38,10 +38,10 @@ struct Observation {
 
     let notify: SCFNotificationCallbackObjC
 
-    init<Observer: AnyObject, Object: AnyObject>(name: CFString?, observer: Observer, object: Object?, notify: SCFNotificationCallback<Observer, Object>?) {
+    init<Observer: AnySendableObject, Object: AnySendableObject>(name: CFString?, observer: Observer, object: Object?, notify: SCFNotificationCallback<Observer, Object>?) {
         self.name = name
-        self.observer = observer as AnyObject?
-        self.object = object as AnyObject?
+        self.observer = observer as AnySendableObject?
+        self.object = object as AnySendableObject?
 
         self.notify = { center, observerPtr, name, objectPtr, userInfo in
             var observer: Observer?

--- a/Sources/SCFNotification/Observation.swift
+++ b/Sources/SCFNotification/Observation.swift
@@ -19,8 +19,8 @@ struct Observation: @unchecked Sendable {
         return .init(name)
     }
 
-    weak var observer: AnySendableObject?
-    weak var object: AnySendableObject?
+    weak var observer: SCFNotificationObserver?
+    weak var object: SCFNotificationObject?
 
     var observerPtr: UnsafeMutableRawPointer? {
         guard let observer = observer else {
@@ -38,10 +38,10 @@ struct Observation: @unchecked Sendable {
 
     let notify: SCFNotificationCallbackObjC
 
-    init<Observer: AnySendableObject, Object: AnySendableObject>(name: CFString?, observer: Observer, object: Object?, notify: SCFNotificationCallback<Observer, Object>?) {
+    init<Observer: SCFNotificationObserver, Object: SCFNotificationObject>(name: CFString?, observer: Observer, object: Object?, notify: SCFNotificationCallback<Observer, Object>?) {
         self.name = name
-        self.observer = observer as AnySendableObject?
-        self.object = object as AnySendableObject?
+        self.observer = observer
+        self.object = object
 
         self.notify = { center, observerPtr, name, objectPtr, userInfo in
             var observer: Observer?
@@ -52,7 +52,7 @@ struct Observation: @unchecked Sendable {
             if let objectPtr, center?.centerType != .darwinNotify {
                 object = unsafeBitCast(objectPtr, to: Object?.self)
             }
-            notify?(center, observer, name, object, userInfo)
+            notify?(center, observer, name?.scfNotificationName, object, userInfo?.scfNotificationUserInfo)
         }
     }
 }

--- a/Sources/SCFNotification/Observation.swift
+++ b/Sources/SCFNotification/Observation.swift
@@ -1,16 +1,16 @@
 //
 //  Observation.swift
-//  
+//
 //
 //  Created by p-x9 on 2023/01/21.
-//  
+//
 //
 
 import Foundation
 
 struct Observation {
     typealias SCFNotificationCallbackObjC = (CFNotificationCenter?, UnsafeMutableRawPointer?, CFNotificationName?, UnsafeRawPointer?, CFDictionary?) -> Void
-    
+
     let name: CFString?
     var notificationName: CFNotificationName? {
         guard let name else {
@@ -18,39 +18,38 @@ struct Observation {
         }
         return .init(name)
     }
-    
+
     weak var observer: AnyObject?
     weak var object: AnyObject?
 
     var observerPtr: UnsafeMutableRawPointer? {
-        guard let observer = self.observer else {
+        guard let observer = observer else {
             return nil
         }
         return unsafeBitCast(observer, to: UnsafeMutableRawPointer?.self)
     }
-    
+
     var objectPtr: UnsafeRawPointer? {
-        guard let object = self.object else {
+        guard let object = object else {
             return nil
         }
         return unsafeBitCast(object, to: UnsafeRawPointer?.self)
     }
-    
+
     let notify: SCFNotificationCallbackObjC
 
     init<Observer: AnyObject, Object: AnyObject>(name: CFString?, observer: Observer, object: Object?, notify: SCFNotificationCallback<Observer, Object>?) {
         self.name = name
         self.observer = observer as AnyObject?
         self.object = object as AnyObject?
-        
+
         self.notify = { center, observerPtr, name, objectPtr, userInfo in
             var observer: Observer?
             if let observerPtr {
                 observer = unsafeBitCast(observerPtr, to: Observer?.self)
             }
             var object: Object?
-            if let objectPtr,
-               center?.centerType != .darwinNotify {
+            if let objectPtr, center?.centerType != .darwinNotify {
                 object = unsafeBitCast(objectPtr, to: Object?.self)
             }
             notify?(center, observer, name, object, userInfo)

--- a/Sources/SCFNotification/ObservationStore.swift
+++ b/Sources/SCFNotification/ObservationStore.swift
@@ -35,11 +35,7 @@ class ObservationStore: @unchecked Sendable {
         }
     }
 
-    func remove(center: SCFNotificationCenter.CenterType,
-                observer: UnsafeMutableRawPointer?,
-                name: CFNotificationName?,
-                object: UnsafeRawPointer?)
-    {
+    func remove(center: SCFNotificationCenter.CenterType, observer: UnsafeMutableRawPointer?, name: CFNotificationName?, object: UnsafeRawPointer?) {
         cleanUp()
 
         switch center {

--- a/Sources/SCFNotification/ObservationStore.swift
+++ b/Sources/SCFNotification/ObservationStore.swift
@@ -1,9 +1,9 @@
 //
 //  ObservationStore.swift
-//  
+//
 //
 //  Created by p-x9 on 2023/01/21.
-//  
+//
 //
 
 import Foundation
@@ -38,7 +38,8 @@ class ObservationStore {
     func remove(center: SCFNotificationCenter.CenterType,
                 observer: UnsafeMutableRawPointer?,
                 name: CFNotificationName?,
-                object: UnsafeRawPointer?) {
+                object: UnsafeRawPointer?)
+    {
         cleanUp()
 
         switch center {
@@ -105,7 +106,6 @@ class ObservationStore {
                 $0.notify(center.cfNotificationCenter, observer, name, object, userInfo)
             }
     }
-
 }
 
 extension ObservationStore {

--- a/Sources/SCFNotification/ObservationStore.swift
+++ b/Sources/SCFNotification/ObservationStore.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-class ObservationStore {
+class ObservationStore: @unchecked Sendable {
     static let shared = ObservationStore()
 
     private(set) var localObservations = [Observation]()
@@ -44,15 +44,12 @@ class ObservationStore {
 
         switch center {
         case .local:
-            localObservations = localObservations
-                .remove(observer: observer, name: name, object: object)
+            localObservations = localObservations.remove(observer: observer, name: name, object: object)
         case .darwinNotify:
-            darwinNotifyObservations = darwinNotifyObservations
-                .remove(observer: observer, name: name, object: object)
+            darwinNotifyObservations = darwinNotifyObservations.remove(observer: observer, name: name, object: object)
 #if os(macOS)
         case .distributed:
-            distributedObservations = distributedObservations
-                .remove(observer: observer, name: name, object: object)
+            distributedObservations = distributedObservations.remove(observer: observer, name: name, object: object)
 #endif
         }
     }
@@ -62,15 +59,12 @@ class ObservationStore {
 
         switch center {
         case .local:
-            localObservations = localObservations
-                .removeEvery(observer: observer)
+            localObservations = localObservations.removeEvery(observer: observer)
         case .darwinNotify:
-            darwinNotifyObservations = darwinNotifyObservations
-                .removeEvery(observer: observer)
+            darwinNotifyObservations = darwinNotifyObservations.removeEvery(observer: observer)
 #if os(macOS)
         case .distributed:
-            distributedObservations = distributedObservations
-                .removeEvery(observer: observer)
+            distributedObservations = distributedObservations.removeEvery(observer: observer)
 #endif
         }
     }
@@ -100,11 +94,9 @@ class ObservationStore {
 #endif
         }
 
-        observations
-            .notifyNeededOnly(observer: observer, name: name, object: object)
-            .forEach {
-                $0.notify(center.cfNotificationCenter, observer, name, object, userInfo)
-            }
+        for item in observations.notifyNeededOnly(observer: observer, name: name, object: object) {
+            item.notify(center.cfNotificationCenter, observer, name, object, userInfo)
+        }
     }
 }
 

--- a/Sources/SCFNotification/SCFNotificationCenter.swift
+++ b/Sources/SCFNotification/SCFNotificationCenter.swift
@@ -6,7 +6,6 @@ public typealias SCFNotificationCallback<Observer: AnyObject, Object: AnyObject>
                                                                                     _ object: Object?,
                                                                                     _ userInfo: CFDictionary?) -> Void
 
-
 public class SCFNotificationCenter {
     public static let local: SCFNotificationCenter = .init(center: .local)
     public static let darwinNotify: SCFNotificationCenter = .init(center: .darwinNotify)
@@ -25,7 +24,8 @@ public class SCFNotificationCenter {
                                                  name: CFNotificationName?,
                                                  object: AnyObject? = nil,
                                                  suspensionBehavior: CFNotificationSuspensionBehavior,
-                                                 callback: @escaping SCFNotificationCallback<Observer, AnyObject>) {
+                                                 callback: @escaping SCFNotificationCallback<Observer, AnyObject>)
+    {
         Self.addObserver(center: center,
                          observer: observer,
                          name: name,
@@ -36,7 +36,8 @@ public class SCFNotificationCenter {
 
     public func removeObserver<Observer: AnyObject>(observer: Observer,
                                                     name: CFNotificationName?,
-                                                    object: AnyObject? = nil) {
+                                                    object: AnyObject? = nil)
+    {
         Self.removeObserver(center: center,
                             observer: observer,
                             name: name,
@@ -44,14 +45,14 @@ public class SCFNotificationCenter {
     }
 
     public func removeEveryObserver<Observer: AnyObject>(observer: Observer) {
-        Self.removeEveryObserver(center: center,
-                                 observer: observer)
+        Self.removeEveryObserver(center: center, observer: observer)
     }
 
     public func postNotification(name: CFNotificationName,
                                  object: AnyObject? = nil,
                                  userInfo: CFDictionary,
-                                 deliverImmediately: Bool) {
+                                 deliverImmediately: Bool)
+    {
         Self.postNotification(center: center,
                               name: name,
                               object: object,
@@ -62,7 +63,8 @@ public class SCFNotificationCenter {
     public func postNotification(name: CFNotificationName,
                                  object: AnyObject? = nil,
                                  userInfo: CFDictionary,
-                                 options: Set<Option>) {
+                                 options: Set<Option>)
+    {
         Self.postNotification(center: center,
                               name: name,
                               object: object,
@@ -71,15 +73,14 @@ public class SCFNotificationCenter {
     }
 }
 
-
-extension SCFNotificationCenter {
-    public static func addObserver<Observer: AnyObject>(center: CenterType,
-                                                        observer: Observer,
-                                                        name: CFNotificationName?,
-                                                        object: AnyObject? = nil,
-                                                        suspensionBehavior: CFNotificationSuspensionBehavior,
-                                                        callback: @escaping SCFNotificationCallback<Observer, AnyObject>) {
-
+public extension SCFNotificationCenter {
+    static func addObserver<Observer: AnyObject>(center: CenterType,
+                                                 observer: Observer,
+                                                 name: CFNotificationName?,
+                                                 object: AnyObject? = nil,
+                                                 suspensionBehavior: CFNotificationSuspensionBehavior,
+                                                 callback: @escaping SCFNotificationCallback<Observer, AnyObject>)
+    {
         var observation = Observation(name: name?.rawValue,
                                       observer: observer,
                                       object: object,
@@ -102,10 +103,11 @@ extension SCFNotificationCenter {
         }, observation.name, observation.objectPtr, suspensionBehavior)
     }
 
-    public static func removeObserver<Observer: AnyObject>(center: CenterType,
-                                                           observer: Observer,
-                                                           name: CFNotificationName?,
-                                                           object: AnyObject? = nil) {
+    static func removeObserver<Observer: AnyObject>(center: CenterType,
+                                                    observer: Observer,
+                                                    name: CFNotificationName?,
+                                                    object: AnyObject? = nil)
+    {
         let observer = unsafeBitCast(observer, to: UnsafeMutableRawPointer.self)
 
         var objectPtr: UnsafeRawPointer?
@@ -122,19 +124,21 @@ extension SCFNotificationCenter {
         CFNotificationCenterRemoveObserver(center.cfNotificationCenter, observer, name, objectPtr)
     }
 
-    public static func removeEveryObserver<Observer: AnyObject>(center: CenterType,
-                                                                observer: Observer) {
+    static func removeEveryObserver<Observer: AnyObject>(center: CenterType,
+                                                         observer: Observer)
+    {
         let observer = unsafeBitCast(observer, to: UnsafeMutableRawPointer.self)
 
         ObservationStore.shared.removeEvery(center: center, observer: observer)
         CFNotificationCenterRemoveEveryObserver(center.cfNotificationCenter, observer)
     }
 
-    public static func postNotification(center: CenterType,
-                                        name: CFNotificationName,
-                                        object: AnyObject? = nil,
-                                        userInfo: CFDictionary,
-                                        deliverImmediately: Bool) {
+    static func postNotification(center: CenterType,
+                                 name: CFNotificationName,
+                                 object: AnyObject? = nil,
+                                 userInfo: CFDictionary,
+                                 deliverImmediately: Bool)
+    {
         var objectPtr: UnsafeRawPointer?
         if let object {
             objectPtr = unsafeBitCast(object, to: UnsafeRawPointer.self)
@@ -143,11 +147,12 @@ extension SCFNotificationCenter {
         CFNotificationCenterPostNotification(center.cfNotificationCenter, name, objectPtr, userInfo, deliverImmediately)
     }
 
-    public static func postNotification(center: CenterType,
-                                        name: CFNotificationName,
-                                        object: AnyObject? = nil,
-                                        userInfo: CFDictionary,
-                                        options: Set<Option>) {
+    static func postNotification(center: CenterType,
+                                 name: CFNotificationName,
+                                 object: AnyObject? = nil,
+                                 userInfo: CFDictionary,
+                                 options: Set<Option>)
+    {
         var objectPtr: UnsafeRawPointer?
         if let object {
             objectPtr = unsafeBitCast(object, to: UnsafeRawPointer.self)
@@ -161,8 +166,8 @@ extension SCFNotificationCenter {
     }
 }
 
-extension SCFNotificationCenter {
-    public enum CenterType {
+public extension SCFNotificationCenter {
+    enum CenterType {
         case local, darwinNotify
 
 #if os(macOS)
@@ -184,8 +189,8 @@ extension SCFNotificationCenter {
     }
 }
 
-extension SCFNotificationCenter {
-    public enum Option: CaseIterable {
+public extension SCFNotificationCenter {
+    enum Option: CaseIterable {
         case deliverImmediately
         case postToAllSessions
 

--- a/Sources/SCFNotification/SCFNotificationCenter.swift
+++ b/Sources/SCFNotification/SCFNotificationCenter.swift
@@ -1,3 +1,11 @@
+//
+//  ObservationStore.swift
+//
+//
+//  Created by p-x9 on 2023/01/21.
+//
+//
+
 import Foundation
 
 // Enforce minimum Swift version for all platforms and build systems.
@@ -5,13 +13,34 @@ import Foundation
 #error("SCFNotification doesn't support Swift versions below 5.9.")
 #endif
 
-public typealias AnySendableObject = AnyObject & Sendable
+/// A type that represents a notification name.
+public typealias SCFNotificationName = String
 
-public typealias SCFNotificationCallback<Observer: AnySendableObject, Object: AnySendableObject>
-    = @Sendable (_ center: CFNotificationCenter?, _ observer: Observer?, _ name: CFNotificationName?, _ object: Object?, _ userInfo: CFDictionary?) -> Void
+/// A type that represents a notification user info dictionary.
+public typealias SCFNotificationUserInfo = [String: Any]
 
-public class SCFNotificationCenter: @unchecked Sendable
-{
+/// A type that represents a notification observer.
+public typealias SCFNotificationObserver = AnyObject & Sendable
+
+/// A type that represents a notification object.
+public typealias SCFNotificationObject = AnyObject
+
+/// A type that represents a notification callback.
+/// This is a closure that will be called when a notification is received.
+/// The closure takes the following parameters:
+/// - `center`: The notification center that posted the notification.
+/// - `observer`: The observer that received the notification.
+/// - `name`: The name of the notification.
+/// - `object`: The object that posted the notification.
+/// - `userInfo`: The user info dictionary that was included with the notification.
+public typealias SCFNotificationCallback<Observer: SCFNotificationObserver, Object: SCFNotificationObject> = @Sendable (_ center: CFNotificationCenter?,
+                                                                                                                        _ observer: Observer?,
+                                                                                                                        _ name: SCFNotificationName?,
+                                                                                                                        _ object: Object?,
+                                                                                                                        _ userInfo: SCFNotificationUserInfo?) -> Void
+
+/// This is a wrapper around `CFNotificationCenter` to provide a more Swift-friendly API.
+public class SCFNotificationCenter: @unchecked Sendable {
     public static let local: SCFNotificationCenter = .init(center: .local)
     public static let darwinNotify: SCFNotificationCenter = .init(center: .darwinNotify)
 
@@ -21,65 +50,70 @@ public class SCFNotificationCenter: @unchecked Sendable
 
     private let center: CenterType
 
-    init(center: CenterType)
-    {
+    init(center: CenterType) {
         self.center = center
     }
 
-    public func addObserver<Observer: AnySendableObject>(observer: Observer,
-                                                         name: CFNotificationName?,
-                                                         object: AnySendableObject? = nil,
-                                                         suspensionBehavior: CFNotificationSuspensionBehavior,
-                                                         callback: @escaping SCFNotificationCallback<Observer, AnySendableObject>)
-    {
+    /// Adds an observer for the specified notification name and object.
+    /// - Parameters:
+    ///   - observer: The observer to add.
+    ///   - name: The name of the notification to observe. If `nil`, the observer will receive all notifications.
+    ///   - object: The object to observe. If `nil`, the observer will receive notifications from all objects.
+    ///   - suspensionBehavior: The suspension behavior for the observer.
+    ///   - callback: The callback to be called when the notification is received.
+    public func addObserver<Observer: SCFNotificationObserver>(observer: Observer, name: SCFNotificationName?, object: SCFNotificationObject? = nil, suspensionBehavior: SCFNotificationCenter.SuspensionBehavior, callback: @escaping SCFNotificationCallback<Observer, SCFNotificationObject>) {
         Self.addObserver(center: center, observer: observer, name: name, object: object, suspensionBehavior: suspensionBehavior, callback: callback)
     }
 
-    public func removeObserver<Observer: AnySendableObject>(observer: Observer,
-                                                            name: CFNotificationName?,
-                                                            object: AnySendableObject? = nil)
-    {
-        Self.removeObserver(center: center,
-                            observer: observer,
-                            name: name,
-                            object: object)
+    /// Removes the observer for the specified notification name and object.
+    /// - Parameters:
+    ///   - observer: The observer to remove.
+    ///   - name: The name of the notification to stop observing. If `nil`, the observer will stop receiving all notifications.
+    ///   - object: The object to stop observing. If `nil`, the observer will stop receiving notifications from all objects.
+    public func removeObserver<Observer: SCFNotificationObserver>(observer: Observer, name: SCFNotificationName?, object: SCFNotificationObject? = nil) {
+        Self.removeObserver(center: center, observer: observer, name: name, object: object)
     }
 
-    public func removeEveryObserver<Observer: AnySendableObject>(observer: Observer)
-    {
+    /// Removes all observers for the specified observer.
+    /// - Parameter observer: The observer to remove.
+    public func removeEveryObserver<Observer: SCFNotificationObserver>(observer: Observer) {
         Self.removeEveryObserver(center: center, observer: observer)
     }
 
-    public func postNotification(name: CFNotificationName,
-                                 object: AnySendableObject? = nil,
-                                 userInfo: CFDictionary,
-                                 deliverImmediately: Bool)
-    {
+    /// Posts a notification with the specified name, object, and user info.
+    /// - Parameters:
+    ///   - name: The name of the notification to post.
+    ///   - object: The object to post the notification for. If `nil`, the notification will be posted for all objects.
+    ///   - userInfo: The user info dictionary to include with the notification.
+    ///   - deliverImmediately: Whether to deliver the notification immediately.
+    public func postNotification(name: SCFNotificationName, object: SCFNotificationObject? = nil, userInfo: SCFNotificationUserInfo, deliverImmediately: Bool) {
         Self.postNotification(center: center, name: name, object: object, userInfo: userInfo, deliverImmediately: deliverImmediately)
     }
 
-    public func postNotification(name: CFNotificationName,
-                                 object: AnySendableObject? = nil,
-                                 userInfo: CFDictionary,
-                                 options: Set<Option>)
-    {
+    /// Posts a notification with the specified name, object, and user info.
+    /// - Parameters:
+    ///   - name: The name of the notification to post.
+    ///   - object: The object to post the notification for. If `nil`, the notification will be posted for all objects.
+    ///   - userInfo: The user info dictionary to include with the notification.
+    ///   - options: The options for the notification.
+    public func postNotification(name: SCFNotificationName, object: SCFNotificationObject? = nil, userInfo: SCFNotificationUserInfo, options: Set<Option>) {
         Self.postNotification(center: center, name: name, object: object, userInfo: userInfo, options: options)
     }
 }
 
-public extension SCFNotificationCenter
-{
-    static func addObserver<Observer: AnySendableObject>(center: CenterType,
-                                                         observer: Observer,
-                                                         name: CFNotificationName?,
-                                                         object: AnySendableObject? = nil,
-                                                         suspensionBehavior: CFNotificationSuspensionBehavior,
-                                                         callback: @escaping SCFNotificationCallback<Observer, AnySendableObject>)
-    {
-        var observation = Observation(name: name?.rawValue, observer: observer, object: object, notify: callback)
+public extension SCFNotificationCenter {
+    /// Adds an observer for the specified notification name and object.
+    /// - Parameters:
+    ///   - center: The notification center to add the observer to.
+    ///   - observer: The observer to add.
+    ///   - name: The name of the notification to observe. If `nil`, the observer will receive all notifications.
+    ///   - object: The object to observe. If `nil`, the observer will receive notifications from all objects.
+    ///   - suspensionBehavior: The suspension behavior for the observer.
+    ///   - callback: The callback to be called when the notification is received.
+    static func addObserver<Observer: SCFNotificationObserver>(center: CenterType, observer: Observer, name: SCFNotificationName?, object: SCFNotificationObject? = nil, suspensionBehavior: SCFNotificationCenter.SuspensionBehavior, callback: @escaping SCFNotificationCallback<Observer, SCFNotificationObject>) {
+        var observation = Observation(name: name as CFString?, observer: observer, object: object, notify: callback)
 
-        if center == .darwinNotify
-        {
+        if center == .darwinNotify {
             observation.object = nil
         }
 
@@ -88,81 +122,86 @@ public extension SCFNotificationCenter
         CFNotificationCenterAddObserver(center.cfNotificationCenter, observation.observerPtr, { center, observer, name, object, userInfo in
             guard let center = center?.centerType else { return }
             ObservationStore.shared.notifyIfNeeded(center: center, observer: observer, name: name, object: object, userInfo: userInfo)
-        }, observation.name, observation.objectPtr, suspensionBehavior)
+        }, observation.name, observation.objectPtr, suspensionBehavior.cfNotificationSuspensionBehavior)
     }
 
-    static func removeObserver<Observer: AnySendableObject>(center: CenterType,
-                                                            observer: Observer,
-                                                            name: CFNotificationName?,
-                                                            object: AnySendableObject? = nil)
-    {
+    /// Removes the observer for the specified notification name and object.
+    /// - Parameters:
+    ///   - center: The notification center to remove the observer from.
+    ///   - observer: The observer to remove.
+    ///   - name: The name of the notification to stop observing. If `nil`, the observer will stop receiving all notifications.
+    ///   - object: The object to stop observing. If `nil`, the observer will stop receiving notifications from all objects.
+    static func removeObserver<Observer: SCFNotificationObserver>(center: CenterType, observer: Observer, name: SCFNotificationName?, object: SCFNotificationObject? = nil) {
         let observer = unsafeBitCast(observer, to: UnsafeMutableRawPointer.self)
 
         var objectPtr: UnsafeRawPointer?
-        if let object
-        {
+        if let object {
             objectPtr = unsafeBitCast(object, to: UnsafeRawPointer.self)
         }
 
-        if center == .darwinNotify
-        {
+        if center == .darwinNotify {
             objectPtr = nil
         }
 
-        ObservationStore.shared.remove(center: center, observer: observer, name: name, object: objectPtr)
+        ObservationStore.shared.remove(center: center, observer: observer, name: name?.cfNotificationName, object: objectPtr)
 
-        CFNotificationCenterRemoveObserver(center.cfNotificationCenter, observer, name, objectPtr)
+        CFNotificationCenterRemoveObserver(center.cfNotificationCenter, observer, name?.cfNotificationName, objectPtr)
     }
 
-    static func removeEveryObserver<Observer: AnySendableObject>(center: CenterType,
-                                                                 observer: Observer)
-    {
+    /// Removes all observers for the specified observer.
+    /// - Parameters:
+    ///  - center: The notification center to remove the observer from.
+    ///  - observer: The observer to remove.
+    static func removeEveryObserver<Observer: SCFNotificationObserver>(center: CenterType, observer: Observer) {
         let observer = unsafeBitCast(observer, to: UnsafeMutableRawPointer.self)
 
         ObservationStore.shared.removeEvery(center: center, observer: observer)
         CFNotificationCenterRemoveEveryObserver(center.cfNotificationCenter, observer)
     }
 
-    static func postNotification(center: CenterType,
-                                 name: CFNotificationName,
-                                 object: AnySendableObject? = nil,
-                                 userInfo: CFDictionary,
-                                 deliverImmediately: Bool)
-    {
+    /// Posts a notification with the specified name, object, and user info.
+    /// - Parameters:
+    ///   - center: The notification center to post the notification to.
+    ///   - name: The name of the notification to post.
+    ///   - object: The object to post the notification for. If `nil`, the notification will be posted for all objects.
+    ///   - userInfo: The user info dictionary to include with the notification.
+    ///   - deliverImmediately: Whether to deliver the notification immediately.
+    static func postNotification(center: CenterType, name: SCFNotificationName, object: SCFNotificationObject? = nil, userInfo: SCFNotificationUserInfo, deliverImmediately: Bool) {
         var objectPtr: UnsafeRawPointer?
-        if let object
-        {
+        if let object {
             objectPtr = unsafeBitCast(object, to: UnsafeRawPointer.self)
         }
 
-        CFNotificationCenterPostNotification(center.cfNotificationCenter, name, objectPtr, userInfo, deliverImmediately)
+        CFNotificationCenterPostNotification(center.cfNotificationCenter, name.cfNotificationName, objectPtr, userInfo.cfDictionary, deliverImmediately)
     }
 
-    static func postNotification(center: CenterType,
-                                 name: CFNotificationName,
-                                 object: AnySendableObject? = nil,
-                                 userInfo: CFDictionary,
-                                 options: Set<Option>)
-    {
+    /// Posts a notification with the specified name, object, and user info.
+    /// - Parameters:
+    ///   - center: The notification center to post the notification to.
+    ///   - name: The name of the notification to post.
+    ///   - object: The object to post the notification for. If `nil`, the notification will be posted for all objects.
+    ///   - userInfo: The user info dictionary to include with the notification.
+    ///   - options: The options for the notification.
+    static func postNotification(center: CenterType, name: SCFNotificationName, object: SCFNotificationObject? = nil, userInfo: SCFNotificationUserInfo, options: Set<Option>) {
         var objectPtr: UnsafeRawPointer?
-        if let object
-        {
+        if let object {
             objectPtr = unsafeBitCast(object, to: UnsafeRawPointer.self)
         }
 
-        let options: CFOptionFlags = options.reduce(into: 0)
-        { partialResult, option in
+        let options: CFOptionFlags = options.reduce(into: 0) { partialResult, option in
             partialResult = partialResult | option.flag
         }
 
-        CFNotificationCenterPostNotificationWithOptions(center.cfNotificationCenter, name, objectPtr, userInfo, options)
+        CFNotificationCenterPostNotificationWithOptions(center.cfNotificationCenter, name.cfNotificationName, objectPtr, userInfo.cfDictionary, options)
     }
 }
 
-public extension SCFNotificationCenter
-{
-    enum CenterType: Sendable
-    {
+public extension SCFNotificationCenter {
+    /// The type of notification center to use.
+    /// - local: The local notification center.
+    /// - darwinNotify: The Darwin notification center.
+    /// - distributed: The distributed notification center (macOS only).
+    enum CenterType: Sendable {
         case local
         case darwinNotify
 
@@ -170,10 +209,8 @@ public extension SCFNotificationCenter
         case distributed
 #endif
 
-        public var cfNotificationCenter: CFNotificationCenter
-        {
-            switch self
-            {
+        public var cfNotificationCenter: CFNotificationCenter {
+            switch self {
             case .local:
                 return CFNotificationCenterGetLocalCenter()
             case .darwinNotify:
@@ -187,19 +224,37 @@ public extension SCFNotificationCenter
     }
 }
 
-public extension SCFNotificationCenter
-{
-    enum Option: Sendable, CaseIterable
-    {
+public extension SCFNotificationCenter {
+    enum Option: Sendable, CaseIterable {
         case deliverImmediately
         case postToAllSessions
 
-        var flag: CFOptionFlags
-        {
-            switch self
-            {
+        var flag: CFOptionFlags {
+            switch self {
             case .deliverImmediately: return kCFNotificationDeliverImmediately
             case .postToAllSessions: return kCFNotificationPostToAllSessions
+            }
+        }
+    }
+}
+
+public extension SCFNotificationCenter {
+    enum SuspensionBehavior: Sendable {
+        case drop
+        case coalesce
+        case hold
+        case deliverImmediately
+
+        var cfNotificationSuspensionBehavior: CFNotificationSuspensionBehavior {
+            switch self {
+            case .drop:
+                return .drop
+            case .coalesce:
+                return .coalesce
+            case .hold:
+                return .hold
+            case .deliverImmediately:
+                return .deliverImmediately
             }
         }
     }

--- a/Sources/SCFNotification/SCFNotificationCenter.swift
+++ b/Sources/SCFNotification/SCFNotificationCenter.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+// Enforce minimum Swift version for all platforms and build systems.
+#if swift(<5.9)
+#error("SCFNotification doesn't support Swift versions below 5.9.")
+#endif
+
 public typealias AnySendableObject = AnyObject & Sendable
 
 public typealias SCFNotificationCallback<Observer: AnySendableObject, Object: AnySendableObject>

--- a/Tests/SCFNotificationTests/SCFDarwinNotificationTests.swift
+++ b/Tests/SCFNotificationTests/SCFDarwinNotificationTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import SCFNotification
+import XCTest
 
 class SCFDarwinNotificationTests: SCFNotificationTests {
     override var centerType: SCFNotificationCenter.CenterType {
@@ -15,14 +15,14 @@ class SCFDarwinNotificationTests: SCFNotificationTests {
             .addObserver(observer: self,
                          name: .init(#function as CFString),
                          object: "hello" as CFString,
-                         suspensionBehavior: .deliverImmediately) { center, observer, name, object, userInfo in
-                XCTAssertEqual(observer, self)
-                XCTAssertEqual(center?.centerType, self.centerType)
-                XCTAssertEqual(name?.rawValue, #function as CFString)
-                XCTAssertNil(object)
-                exp.fulfill()
-            }
-
+                         suspensionBehavior: .deliverImmediately)
+        { center, observer, name, object, _ in
+            XCTAssertEqual(observer, self)
+            XCTAssertEqual(center?.centerType, self.centerType)
+            XCTAssertEqual(name?.rawValue, #function as CFString)
+            XCTAssertNil(object)
+            exp.fulfill()
+        }
 
         notificationCenter.postNotification(name: .init(#function as CFString),
                                             object: "hello" as CFString,
@@ -40,10 +40,10 @@ class SCFDarwinNotificationTests: SCFNotificationTests {
             .addObserver(observer: self,
                          name: .init("\(#function)" as CFString),
                          object: "hello-aaa" as CFString,
-                         suspensionBehavior: .deliverImmediately) { center, observer, name, object, userInfo in
-                exp.fulfill()
-            }
-
+                         suspensionBehavior: .deliverImmediately)
+        { _, _, _, _, _ in
+            exp.fulfill()
+        }
 
         notificationCenter.postNotification(name: .init(#function as CFString),
                                             object: "hello" as CFString,
@@ -64,10 +64,10 @@ class SCFDarwinNotificationTests: SCFNotificationTests {
         notificationCenter
             .addObserver(observer: self,
                          name: nil,
-                         suspensionBehavior: .deliverImmediately) { center, observer, name, object, userInfo in
-                exp.fulfill()
-            }
-
+                         suspensionBehavior: .deliverImmediately)
+        { _, _, _, _, _ in
+            exp.fulfill()
+        }
 
         notificationCenter.postNotification(name: .init(#function as CFString),
                                             userInfo: [:] as CFDictionary,
@@ -88,10 +88,10 @@ class SCFDarwinNotificationTests: SCFNotificationTests {
             .addObserver(observer: self,
                          name: nil,
                          object: "hello" as CFString,
-                         suspensionBehavior: .deliverImmediately) { center, observer, name, object, userInfo in
-                exp.fulfill()
-            }
-
+                         suspensionBehavior: .deliverImmediately)
+        { _, _, _, _, _ in
+            exp.fulfill()
+        }
 
         notificationCenter.postNotification(name: .init(#function as CFString),
                                             object: "hello" as CFString,

--- a/Tests/SCFNotificationTests/SCFDarwinNotificationTests.swift
+++ b/Tests/SCFNotificationTests/SCFDarwinNotificationTests.swift
@@ -1,7 +1,7 @@
 @testable import SCFNotification
-import XCTest
+@preconcurrency import XCTest
 
-class SCFDarwinNotificationTests: SCFNotificationTests {
+class SCFDarwinNotificationTests: SCFNotificationTests, @unchecked Sendable {
     override var centerType: SCFNotificationCenter.CenterType {
         .darwinNotify
     }
@@ -13,20 +13,20 @@ class SCFDarwinNotificationTests: SCFNotificationTests {
 
         notificationCenter
             .addObserver(observer: self,
-                         name: .init(#function as CFString),
+                         name: #function,
                          object: "hello" as CFString,
                          suspensionBehavior: .deliverImmediately)
         { center, observer, name, object, _ in
             XCTAssertEqual(observer, self)
             XCTAssertEqual(center?.centerType, self.centerType)
-            XCTAssertEqual(name?.rawValue, #function as CFString)
+            XCTAssertEqual(name, #function)
             XCTAssertNil(object)
             exp.fulfill()
         }
 
-        notificationCenter.postNotification(name: .init(#function as CFString),
+        notificationCenter.postNotification(name: #function,
                                             object: "hello" as CFString,
-                                            userInfo: [:] as CFDictionary,
+                                            userInfo: [:],
                                             deliverImmediately: true)
 
         wait(for: [exp], timeout: timeout)
@@ -38,16 +38,16 @@ class SCFDarwinNotificationTests: SCFNotificationTests {
 
         notificationCenter
             .addObserver(observer: self,
-                         name: .init("\(#function)" as CFString),
+                         name: #function,
                          object: "hello-aaa" as CFString,
                          suspensionBehavior: .deliverImmediately)
         { _, _, _, _, _ in
             exp.fulfill()
         }
 
-        notificationCenter.postNotification(name: .init(#function as CFString),
+        notificationCenter.postNotification(name: #function,
                                             object: "hello" as CFString,
-                                            userInfo: [:] as CFDictionary,
+                                            userInfo: [:],
                                             deliverImmediately: true)
 
         wait(for: [exp], timeout: timeout)
@@ -69,8 +69,8 @@ class SCFDarwinNotificationTests: SCFNotificationTests {
             exp.fulfill()
         }
 
-        notificationCenter.postNotification(name: .init(#function as CFString),
-                                            userInfo: [:] as CFDictionary,
+        notificationCenter.postNotification(name: #function,
+                                            userInfo: [:],
                                             deliverImmediately: true)
 
         wait(for: [exp], timeout: timeout)
@@ -93,9 +93,9 @@ class SCFDarwinNotificationTests: SCFNotificationTests {
             exp.fulfill()
         }
 
-        notificationCenter.postNotification(name: .init(#function as CFString),
+        notificationCenter.postNotification(name: #function,
                                             object: "hello" as CFString,
-                                            userInfo: [:] as CFDictionary,
+                                            userInfo: [:],
                                             deliverImmediately: true)
 
         wait(for: [exp], timeout: timeout)

--- a/Tests/SCFNotificationTests/SCFDistributedNotificationTests.swift
+++ b/Tests/SCFNotificationTests/SCFDistributedNotificationTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import SCFNotification
+import XCTest
 
 class SCFDistributedNotificationTests: SCFNotificationTests {
     override var centerType: SCFNotificationCenter.CenterType {
@@ -15,9 +15,10 @@ class SCFDistributedNotificationTests: SCFNotificationTests {
         notificationCenter
             .addObserver(observer: self,
                          name: nil,
-                         suspensionBehavior: .deliverImmediately) { center, observer, name, object, userInfo in
-                exp.fulfill()
-            }
+                         suspensionBehavior: .deliverImmediately)
+        { _, _, _, _, _ in
+            exp.fulfill()
+        }
 
         notificationCenter.postNotification(name: .init(#function as CFString),
                                             userInfo: [:] as CFDictionary,

--- a/Tests/SCFNotificationTests/SCFDistributedNotificationTests.swift
+++ b/Tests/SCFNotificationTests/SCFDistributedNotificationTests.swift
@@ -1,7 +1,7 @@
 @testable import SCFNotification
 import XCTest
 
-class SCFDistributedNotificationTests: SCFNotificationTests {
+class SCFDistributedNotificationTests: SCFNotificationTests, @unchecked Sendable {
     override var centerType: SCFNotificationCenter.CenterType {
         .distributed
     }
@@ -20,12 +20,37 @@ class SCFDistributedNotificationTests: SCFNotificationTests {
             exp.fulfill()
         }
 
-        notificationCenter.postNotification(name: .init(#function as CFString),
-                                            userInfo: [:] as CFDictionary,
+        notificationCenter.postNotification(name: #function,
+                                            userInfo: [:],
                                             deliverImmediately: true)
 
         wait(for: [exp], timeout: timeout)
 
+        removeEveryObserver()
+    }
+
+    func testObserveNamedWithUserInfo() {
+        let exp = expectation(description: #function)
+        let key = "key"
+        let value = "hello"
+
+        notificationCenter
+            .addObserver(observer: self,
+                         name: #function,
+                         suspensionBehavior: .deliverImmediately)
+        { center, observer, name, _, userInfo in
+            XCTAssertEqual(observer, self)
+            XCTAssertEqual(center?.centerType, self.centerType)
+            XCTAssertEqual(name, #function)
+            XCTAssertEqual(value, userInfo?[key] as? String)
+            exp.fulfill()
+        }
+
+        notificationCenter.postNotification(name: #function,
+                                            userInfo: [key: value],
+                                            deliverImmediately: true)
+
+        wait(for: [exp], timeout: timeout)
         removeEveryObserver()
     }
 }

--- a/Tests/SCFNotificationTests/SCFNotificationTests.swift
+++ b/Tests/SCFNotificationTests/SCFNotificationTests.swift
@@ -6,7 +6,7 @@ import XCTest
 /// 　Perhaps each time one test method is called, Xcode makes a copy and continues with the rest of the tests.
 /// 　Therefore, each time one method is called, we call the `removeEveryObserver` method at the end of it.
 
-class SCFNotificationTests: XCTestCase {
+class SCFNotificationTests: XCTestCase, @unchecked Sendable {
     var centerType: SCFNotificationCenter.CenterType { .local }
     lazy var notificationCenter: SCFNotificationCenter = .init(center: centerType)
     var observationStore: ObservationStore = .shared
@@ -33,17 +33,17 @@ class SCFNotificationTests: XCTestCase {
 
         notificationCenter
             .addObserver(observer: self,
-                         name: .init(#function as CFString),
+                         name: #function,
                          suspensionBehavior: .deliverImmediately)
         { center, observer, name, _, _ in
             XCTAssertEqual(observer, self)
             XCTAssertEqual(center?.centerType, self.centerType)
-            XCTAssertEqual(name?.rawValue, #function as CFString)
+            XCTAssertEqual(name, #function)
             exp.fulfill()
         }
 
-        notificationCenter.postNotification(name: .init(#function as CFString),
-                                            userInfo: [:] as CFDictionary,
+        notificationCenter.postNotification(name: #function,
+                                            userInfo: [:],
                                             deliverImmediately: true)
 
         wait(for: [exp], timeout: timeout)
@@ -57,14 +57,14 @@ class SCFNotificationTests: XCTestCase {
 
         notificationCenter
             .addObserver(observer: self,
-                         name: .init("\(#function)-aaa" as CFString),
+                         name: "\(#function)-aaa",
                          suspensionBehavior: .deliverImmediately)
         { _, _, _, _, _ in
             exp.fulfill()
         }
 
-        notificationCenter.postNotification(name: .init(#function as CFString),
-                                            userInfo: [:] as CFDictionary,
+        notificationCenter.postNotification(name: #function,
+                                            userInfo: [:],
                                             deliverImmediately: true)
 
         wait(for: [exp], timeout: timeout)
@@ -77,20 +77,20 @@ class SCFNotificationTests: XCTestCase {
 
         notificationCenter
             .addObserver(observer: self,
-                         name: .init(#function as CFString),
+                         name: #function,
                          object: "hello" as CFString,
                          suspensionBehavior: .deliverImmediately)
         { center, observer, name, object, _ in
             XCTAssertEqual(observer, self)
             XCTAssertEqual(center?.centerType, self.centerType)
-            XCTAssertEqual(name?.rawValue, #function as CFString)
+            XCTAssertEqual(name, #function)
             XCTAssertEqual(object as! CFString, "hello" as CFString)
             exp.fulfill()
         }
 
-        notificationCenter.postNotification(name: .init(#function as CFString),
+        notificationCenter.postNotification(name: #function,
                                             object: "hello" as CFString,
-                                            userInfo: [:] as CFDictionary,
+                                            userInfo: [:],
                                             deliverImmediately: true)
 
         wait(for: [exp], timeout: timeout)
@@ -103,16 +103,16 @@ class SCFNotificationTests: XCTestCase {
 
         notificationCenter
             .addObserver(observer: self,
-                         name: .init("\(#function)" as CFString),
+                         name: #function,
                          object: "hello-aaa" as CFString,
                          suspensionBehavior: .deliverImmediately)
         { _, _, _, _, _ in
             exp.fulfill()
         }
 
-        notificationCenter.postNotification(name: .init(#function as CFString),
+        notificationCenter.postNotification(name: #function,
                                             object: "hello" as CFString,
-                                            userInfo: [:] as CFDictionary,
+                                            userInfo: [:],
                                             deliverImmediately: true)
 
         wait(for: [exp], timeout: timeout)
@@ -130,12 +130,12 @@ class SCFNotificationTests: XCTestCase {
         { center, observer, name, _, _ in
             XCTAssertEqual(observer, self)
             XCTAssertEqual(center?.centerType, self.centerType)
-            XCTAssertEqual(name?.rawValue, #function as CFString)
+            XCTAssertEqual(name, #function)
             exp.fulfill()
         }
 
-        notificationCenter.postNotification(name: .init(#function as CFString),
-                                            userInfo: [:] as CFDictionary,
+        notificationCenter.postNotification(name: #function,
+                                            userInfo: [:],
                                             deliverImmediately: true)
 
         wait(for: [exp], timeout: timeout)
@@ -154,14 +154,14 @@ class SCFNotificationTests: XCTestCase {
         { center, observer, name, object, _ in
             XCTAssertEqual(observer, self)
             XCTAssertEqual(center?.centerType, self.centerType)
-            XCTAssertEqual(name?.rawValue, #function as CFString)
+            XCTAssertEqual(name, #function)
             XCTAssertEqual(object as! CFString, "hello" as CFString)
             exp.fulfill()
         }
 
-        notificationCenter.postNotification(name: .init(#function as CFString),
+        notificationCenter.postNotification(name: #function,
                                             object: "hello" as CFString,
-                                            userInfo: [:] as CFDictionary,
+                                            userInfo: [:],
                                             deliverImmediately: true)
 
         wait(for: [exp], timeout: timeout)
@@ -182,9 +182,9 @@ class SCFNotificationTests: XCTestCase {
             exp.fulfill()
         }
 
-        notificationCenter.postNotification(name: .init(#function as CFString),
+        notificationCenter.postNotification(name: #function,
                                             object: "hello" as CFString,
-                                            userInfo: [:] as CFDictionary,
+                                            userInfo: [:],
                                             deliverImmediately: true)
 
         wait(for: [exp], timeout: timeout)

--- a/Tests/SCFNotificationTests/SCFNotificationTests.swift
+++ b/Tests/SCFNotificationTests/SCFNotificationTests.swift
@@ -1,10 +1,10 @@
-import XCTest
 @testable import SCFNotification
+import XCTest
 
 /// NOTE:
-///　When I check the pointer of self in the setUp method, it changes every time.
-///　Perhaps each time one test method is called, Xcode makes a copy and continues with the rest of the tests.
-///　Therefore, each time one method is called, we call the `removeEveryObserver` method at the end of it.
+/// 　When I check the pointer of self in the setUp method, it changes every time.
+/// 　Perhaps each time one test method is called, Xcode makes a copy and continues with the rest of the tests.
+/// 　Therefore, each time one method is called, we call the `removeEveryObserver` method at the end of it.
 
 class SCFNotificationTests: XCTestCase {
     var centerType: SCFNotificationCenter.CenterType { .local }
@@ -25,7 +25,6 @@ class SCFNotificationTests: XCTestCase {
         notificationCenter
             .removeEveryObserver(observer: self)
 
-
         XCTAssertTrue(observationStore.observations(for: centerType).isEmpty)
     }
 
@@ -35,13 +34,13 @@ class SCFNotificationTests: XCTestCase {
         notificationCenter
             .addObserver(observer: self,
                          name: .init(#function as CFString),
-                         suspensionBehavior: .deliverImmediately) { center, observer, name, object, userInfo in
-                XCTAssertEqual(observer, self)
-                XCTAssertEqual(center?.centerType, self.centerType)
-                XCTAssertEqual(name?.rawValue, #function as CFString)
-                exp.fulfill()
-            }
-
+                         suspensionBehavior: .deliverImmediately)
+        { center, observer, name, _, _ in
+            XCTAssertEqual(observer, self)
+            XCTAssertEqual(center?.centerType, self.centerType)
+            XCTAssertEqual(name?.rawValue, #function as CFString)
+            exp.fulfill()
+        }
 
         notificationCenter.postNotification(name: .init(#function as CFString),
                                             userInfo: [:] as CFDictionary,
@@ -59,10 +58,10 @@ class SCFNotificationTests: XCTestCase {
         notificationCenter
             .addObserver(observer: self,
                          name: .init("\(#function)-aaa" as CFString),
-                         suspensionBehavior: .deliverImmediately) { center, observer, name, object, userInfo in
-                exp.fulfill()
-            }
-
+                         suspensionBehavior: .deliverImmediately)
+        { _, _, _, _, _ in
+            exp.fulfill()
+        }
 
         notificationCenter.postNotification(name: .init(#function as CFString),
                                             userInfo: [:] as CFDictionary,
@@ -80,14 +79,14 @@ class SCFNotificationTests: XCTestCase {
             .addObserver(observer: self,
                          name: .init(#function as CFString),
                          object: "hello" as CFString,
-                         suspensionBehavior: .deliverImmediately) { center, observer, name, object, userInfo in
-                XCTAssertEqual(observer, self)
-                XCTAssertEqual(center?.centerType, self.centerType)
-                XCTAssertEqual(name?.rawValue, #function as CFString)
-                XCTAssertEqual(object as! CFString, "hello" as CFString)
-                exp.fulfill()
-            }
-
+                         suspensionBehavior: .deliverImmediately)
+        { center, observer, name, object, _ in
+            XCTAssertEqual(observer, self)
+            XCTAssertEqual(center?.centerType, self.centerType)
+            XCTAssertEqual(name?.rawValue, #function as CFString)
+            XCTAssertEqual(object as! CFString, "hello" as CFString)
+            exp.fulfill()
+        }
 
         notificationCenter.postNotification(name: .init(#function as CFString),
                                             object: "hello" as CFString,
@@ -106,10 +105,10 @@ class SCFNotificationTests: XCTestCase {
             .addObserver(observer: self,
                          name: .init("\(#function)" as CFString),
                          object: "hello-aaa" as CFString,
-                         suspensionBehavior: .deliverImmediately) { center, observer, name, object, userInfo in
-                exp.fulfill()
-            }
-
+                         suspensionBehavior: .deliverImmediately)
+        { _, _, _, _, _ in
+            exp.fulfill()
+        }
 
         notificationCenter.postNotification(name: .init(#function as CFString),
                                             object: "hello" as CFString,
@@ -127,13 +126,13 @@ class SCFNotificationTests: XCTestCase {
         notificationCenter
             .addObserver(observer: self,
                          name: nil,
-                         suspensionBehavior: .deliverImmediately) { center, observer, name, object, userInfo in
-                XCTAssertEqual(observer, self)
-                XCTAssertEqual(center?.centerType, self.centerType)
-                XCTAssertEqual(name?.rawValue, #function as CFString)
-                exp.fulfill()
-            }
-
+                         suspensionBehavior: .deliverImmediately)
+        { center, observer, name, _, _ in
+            XCTAssertEqual(observer, self)
+            XCTAssertEqual(center?.centerType, self.centerType)
+            XCTAssertEqual(name?.rawValue, #function as CFString)
+            exp.fulfill()
+        }
 
         notificationCenter.postNotification(name: .init(#function as CFString),
                                             userInfo: [:] as CFDictionary,
@@ -151,14 +150,14 @@ class SCFNotificationTests: XCTestCase {
             .addObserver(observer: self,
                          name: nil,
                          object: "hello" as CFString,
-                         suspensionBehavior: .deliverImmediately) { center, observer, name, object, userInfo in
-                XCTAssertEqual(observer, self)
-                XCTAssertEqual(center?.centerType, self.centerType)
-                XCTAssertEqual(name?.rawValue, #function as CFString)
-                XCTAssertEqual(object as! CFString, "hello" as CFString)
-                exp.fulfill()
-            }
-
+                         suspensionBehavior: .deliverImmediately)
+        { center, observer, name, object, _ in
+            XCTAssertEqual(observer, self)
+            XCTAssertEqual(center?.centerType, self.centerType)
+            XCTAssertEqual(name?.rawValue, #function as CFString)
+            XCTAssertEqual(object as! CFString, "hello" as CFString)
+            exp.fulfill()
+        }
 
         notificationCenter.postNotification(name: .init(#function as CFString),
                                             object: "hello" as CFString,
@@ -178,10 +177,10 @@ class SCFNotificationTests: XCTestCase {
             .addObserver(observer: self,
                          name: nil,
                          object: "hello-aaa" as CFString,
-                         suspensionBehavior: .deliverImmediately) { center, observer, name, object, userInfo in
-                exp.fulfill()
-            }
-
+                         suspensionBehavior: .deliverImmediately)
+        { _, _, _, _, _ in
+            exp.fulfill()
+        }
 
         notificationCenter.postNotification(name: .init(#function as CFString),
                                             object: "hello" as CFString,


### PR DESCRIPTION
Introduced in Xcode 15, Apple is now flagging specific APIs as needed a “Required Reason” to use. All usages of “Required Reason” APIs MUST be outlined in a Privacy manifest. A Privacy manifest is a document outlining how your app/SDK collects and uses a user’s data.

https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests